### PR TITLE
Fixed an issue with the framerate causing inaccurate times

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 	<h2>Video Framerate</h2>
 	<p class="toggleable">
 		Right click the YouTube video and select “Stats for nerds.” The third line is
-		“Current / Optimal Res” - find the two numbers after the @ and enter them for
+		“Current / Optimal Res” - find the numbers after the @ and enter them for
 		framerate.
 	</p>
 	<p>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 	</p>
 	<h2>Video Endpoints</h2>
 	<p class="toggleable">
-		Find the starting point (you can use the <code>,</code> and <code>.</code> keys to
+		Find the starting point (you can use the <kbd>,</kbd> and <kbd>.</kbd> keys to
 		find the exact frame). Right click the video and select “Copy debug info” and paste
 		it for starting frame. Repeat for ending frame.
 	</p>

--- a/index.html
+++ b/index.html
@@ -63,11 +63,11 @@
 	</p>
 	<p>
 		<label for="startobj">Starting frame: </label>
-		<input type="text" id="startobj" class="own_line" onchange='parse_time(event)'>
+		<input type="text" id="startobj" class="own_line" originalvalue="" onchange='parse_time(event)'>
 	</p>
 	<p>
 		<label for="endobj">Ending frame: </label>
-		<input type="text" id="endobj" class="own_line" onchange='parse_time(event)'>
+		<input type="text" id="endobj" class="own_line" originalvalue="" onchange='parse_time(event)'>
 	</p>
 	<h2>Video Time</h2>
 	<p>

--- a/main.js
+++ b/main.js
@@ -143,7 +143,7 @@ function parse_time(event)
 	const frame = ~~(input * fps) / fps;
 	document.getElementById(event.target.id).value = `${frame}`;
 
-	/* If all fields are filled the compute */
+	/* If all fields are filled then compute */
 	if (document.getElementById("startobj").value && document.getElementById("endobj").value)
 		compute();
 }

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ function compute()
 		return;
 	}
 
-	const seconds = Math.round(frames / fps * 1000) / 1000;
+	const seconds = (frames / fps).toFixed(3);
 
 	/* Show the time and mod message in the DOM. */
 	const s_frame = ~~(s_time * fps);
@@ -106,42 +106,59 @@ function copy_mod_message()
 /* If framerate is invalid, show an error message and disable start and end frame fields. */
 function check_fps(event)
 {
+	const s_time = document.getElementById("startobj");
+	const e_time = document.getElementById("endobj"); 
+
 	fps = event.target.value;
 	if (fps > 0 && fps % 1 == 0) {
-		document.getElementById("startobj").disabled = false;
-		document.getElementById("endobj").disabled = false;
+		s_time.disabled = false;
+		e_time.disabled = false;
 	}
 	else {
 		document.getElementById("framerate")
 			.setCustomValidity("Please enter a valid framerate.");
 		document.getElementById("framerate").reportValidity();
-		document.getElementById("startobj").disabled = true;
-		document.getElementById("endobj").disabled = true;
+		s_time.disabled = true;
+		e_time.disabled = true;
 	}
+	
+	calculate_frames(s_time, s_time.getAttribute("originalvalue"))
+	calculate_frames(e_time, e_time.getAttribute("originalvalue"))
 }
 
 /* Get current frame from input field (either start time or end time). */
 function parse_time(event)
 {
+	const element = document.getElementById(event.target.id);
+	sessionStorage.setItem(event.target.id, element.getAttribute("originalvalue"))
+
 	/* Return early if invalid JSON is passed (numbers are valid) */
 	let input, dinfo;
 	try {
-		dinfo = JSON.parse(event.target.value);
+		dinfo = JSON.parse(element.value);
 	} catch {
-		document.getElementById(event.target.id).value = "";
+		element.value = "";
 		return;
 	}
 
 	/* If cmt isn't available fallback to lct, also allow raw numbers */
 	if (!(input = dinfo.cmt) && !(input = dinfo.lct) && typeof ((input = dinfo)) !== "number") {
-		document.getElementById(event.target.id).value = "";
+		element.value = "";
 		return;
 	}
+	
+	element.setAttribute("originalvalue", input)
+
+	calculate_frames(element, input);
+}
+
+function calculate_frames(element, value) {
+	if(!element.value) return;
 
 	/* Calculate the exact timestamp */
 	const fps = parseInt(document.getElementById("framerate").value);
-	const frame = ~~(input * fps) / fps;
-	document.getElementById(event.target.id).value = `${frame}`;
+	const frame = ~~(value * fps) / fps;
+	element.value = `${frame}`;
 
 	/* If all fields are filled then compute */
 	if (document.getElementById("startobj").value && document.getElementById("endobj").value)

--- a/style.css
+++ b/style.css
@@ -73,7 +73,7 @@ button, h1, h2, input, p, textarea {
 	color: var(--text-color);
 }
 
-button, input, code, textarea {
+button, input, kbd, textarea {
 	background-color: var(--box-color);
 }
 
@@ -92,7 +92,7 @@ button {
 	text-transform: none;
 }
 
-code {
+kbd {
 	font-family: Roboto Mono, Lucida Sans Typewriter, Lucida Console, monaco, Courrier,
 		monospace;
 	font-size: 1em;
@@ -108,7 +108,7 @@ textarea {
 	overflow: auto;
 }
 
-button, code, input, textarea {
+button, kbd, input, textarea {
 	border: none;
 	border-radius: 6px;
 	font-family: sans-serif;


### PR DESCRIPTION
* Changed the `code` tags to `kbd` tags which are meant for keyboard input
* The exact timestamp for the start and end frames are now calculated when the framerate value is updated.
When setting the start and end frame it does some math on those 2 values to make them valid for the framerate that you've entered but if the framerate is changed again then those calculations don't happen causing inaccurate times